### PR TITLE
Add data argument to geom_dl().

### DIFF
--- a/R/ggplot2.R
+++ b/R/ggplot2.R
@@ -30,6 +30,7 @@ GeomDl <- ggplot2::ggproto("GeomDl", ggplot2::Geom,
 geom_dl <- structure(function
 ### Geom that will plot direct labels.
 (mapping=NULL,
+ data=NULL,
 ### aes(label=variable_that_will_be_used_as_groups_in_Positioning_Methods).
  method,
 ### Positioning Method.
@@ -43,6 +44,7 @@ geom_dl <- structure(function
 
   layer(
     mapping = mapping,
+    data = data,
     stat = ggplot2::StatIdentity,
     geom = GeomDl,
     position = PositionIdentity,


### PR DESCRIPTION
I like to use directlabels to label certain subsets of my data so and as a result, I'd like `geom_dl()` to continue to accept a `data` argument.

Will this patch suffice?

Thank you!

Michael

P.S. - @hadley, @tdhock -- also, thank you very much for porting directlabels to work with ggplot2 HEAD!